### PR TITLE
reduce image size by using apt-get clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN set -xe \
        curl \
        git-core \
        gunicorn3 \
+       procps \
  && rm -rf /var/lib/apt/lists/* \
            /var/cache/apt/archives

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ FROM python:3.11.6-slim
 WORKDIR /app
 
 # pulled out:
-# python3-dev \
-# postgresql-client \
+# python3-dev
+# postgresql-client
 RUN set -xe \
-  && pip install pipenv==2023.10.3 poetry==1.6.1 \
-  && apt-get update -q \
-  && apt-get install -y -q \
-        gcc \
-        libssl-dev \
-        curl \
-        git-core \
-        gunicorn3
-
-WORKDIR /app
+ && pip install pipenv==2023.10.3 poetry==1.6.1 \
+ && apt-get update -q \
+ && apt-get install -y -q \
+       gcc \
+       libssl-dev \
+       curl \
+       git-core \
+       gunicorn3 \
+ && rm -rf /var/lib/apt/lists/* \
+           /var/cache/apt/archives


### PR DESCRIPTION
Before:
```
REPOSITORY         TAG       IMAGE ID       CREATED         SIZE
sartography/node   latest    c9fde62c078f   8 seconds ago   649MB
```
After:
```
REPOSITORY         TAG       IMAGE ID       CREATED         SIZE
sartography/node   latest    ca14374b7d77   7 seconds ago   630MB
```

Also removed pointless second `WORKDIR`. And added `procps` for debugging.